### PR TITLE
Readme tweak

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ your ``~/.pypirc`` file::
     [local]
     username:user
     password:secret
-    repository:http://localhost:8000/pypi
+    repository:http://localhost:8000/pypi/
 
 Uploading a package: Python >=2.6
 _________________________________


### PR DESCRIPTION
The version from the Readme raises a 500 when you follow line for line. 

Looks like adding the slash shouldn't matter, but for Django 1.3 Python 2.7 at least, it does :)
