### PR TITLE
Fixed url as mentioned in issue #30

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author_email='askh@opera.com',
     maintainer='Benjamin Liles',
     maintainer_email='benliles@gmail.com',
-    url='http://github.com/benliles/chishop',
+    url='http://github.com/benliles/djangopypi',
     license='BSD',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Fixed url as mentioned in issue #30. Currently pypi still points to a GitHub 404 page
