### PR TITLE
Fixed typo in csrf_exempt decorator (exempt != except).

### DIFF
--- a/djangopypi/decorators.py
+++ b/djangopypi/decorators.py
@@ -22,7 +22,7 @@ except ImportError:
     try:
         from django.contrib.csrf.middleware import csrf_exempt
     except ImportError:
-        def csrf_except(view_func): return view_func
+        def csrf_exempt(view_func): return view_func
 
 def basic_auth(view_func):
     """ Decorator for views that need to handle basic authentication such as


### PR DESCRIPTION
Simple fix for really old Django versions that have no csrf_exempt decorator. Not sure what the Django suport range for djangopypi is anyway.
