### PR TITLE
Updated README file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,7 +176,7 @@ package is not on your new server, or in particular if you are installing a numb
 of packages, some on your private server and some on another, you can use
 pip in the following manner::
 
- $ pip install -i http://localhost:8000/simple/ \
+ $ pip install -i http://my.pypiserver.com/simple/ \
    --extra-index-url=http://pypi.python.org/simple/ \
    -r requirements.txt
 
@@ -185,3 +185,18 @@ pip in the following manner::
 The downside is that each install of a package hosted on the repository in
 ``--extra-index-url`` will start with a call to the first repository which
 will fail before pip falls back to the alternative.
+
+Transparent proxy to an upstream PyPi repository
+++++++++++++++++++++++++++++++++++++++++++++++++
+
+The above method works well, but you can also let djangopypi do the hard work
+and redirect to an upstream index if the requested package is not found
+locally. By default this is disabled. To enable proxying to the default
+upstream repository ``http://pypi.python.org`` the following must be set in
+``settings.py``::
+
+ DJANGOPYPI_PROXY_MISSING = True
+
+If you'd like to fall-back to some other repository, also add::
+
+ DJANGOPYPI_PROXY_BASE_URL = 'http://my.pypirepository.org'

--- a/README.rst
+++ b/README.rst
@@ -161,9 +161,6 @@ To push the package to the local pypi::
 
     $ python setup.py mregister -r local sdist mupload -r local
 
-.. [#] ``djangopypi`` is South enabled, if you are using South then you will need
-   to run the South ``migrate`` command to get the tables.
-
 Installing a package with pip
 -----------------------------
 
@@ -187,7 +184,7 @@ The downside is that each install of a package hosted on the repository in
 will fail before pip falls back to the alternative.
 
 Transparent proxy to an upstream PyPi repository
-++++++++++++++++++++++++++++++++++++++++++++++++
+________________________________________________
 
 The above method works well, but you can also let djangopypi do the hard work
 and redirect to an upstream index if the requested package is not found
@@ -199,4 +196,7 @@ upstream repository ``http://pypi.python.org`` the following must be set in
 
 If you'd like to fall-back to some other repository, also add::
 
- DJANGOPYPI_PROXY_BASE_URL = 'http://my.pypirepository.org'
+ DJANGOPYPI_PROXY_BASE_URL = 'http://my.alternativepypi.com'
+
+.. [#] ``djangopypi`` is South enabled, if you are using South then you will need
+   to run the South ``migrate`` command to get the tables.

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ You may change the directory to which packages are uploaded by setting
 Other settings
 ++++++++++++++
 
-Look in the ``djangopy`` source code for ``settings.py`` to see other
+Look in the ``djangopypi`` source code for ``settings.py`` to see other
 settings you can override.
 
 

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ This will make the repository interface be accessible at ``/pypi/``.
 
 
 Package upload directory
-^^^^^^^^^^^^^^^^^^^^^^^^
+++++++++++++++++++++++++
 
 By default packages are uploaded to ``<MEDIA_ROOT>/dists`` so you need both
 to ensure that ``MEDIA_ROOT`` is assigned a value and that the
@@ -58,14 +58,14 @@ You may change the directory to which packages are uploaded by setting
 
 
 Other settings
-^^^^^^^^^^^^^^
+++++++++++++++
 
 Look in the ``djangopy`` source code for ``settings.py`` to see other
 settings you can override.
 
 
 Data initialisation
-^^^^^^^^^^^^^^^^^^^
++++++++++++++++++++
 
 Load the classifier database with the management command::
 
@@ -73,7 +73,7 @@ Load the classifier database with the management command::
 
 
 Package download handler
-^^^^^^^^^^^^^^^^^^^^^^^^
+++++++++++++++++++++++++
 
 Packages are downloaded from the following URL:
 ``<host>/simple/<package>/dists/<package>-<version>.tar.gz#<md5 hash>``

--- a/README.rst
+++ b/README.rst
@@ -172,11 +172,13 @@ To install your package with pip::
  $ pip install -i http://my.pypiserver.com/simple/ <PACKAGE>
 
 If you want to fall back to PyPi or another repository in the event the
-package is not on your new server, or if you are installing a number
-of packages, some on your private server and some on another, you can use::
+package is not on your new server, or in particular if you are installing a number
+of packages, some on your private server and some on another, you can use
+pip in the following manner::
 
  $ pip install -i http://localhost:8000/simple/ \
-   --extra-index-url=http://pypi.python.org/simple/
+   --extra-index-url=http://pypi.python.org/simple/ \
+   -r requirements.txt
 
 (substitute your djangopypi server URL for the ``localhost`` one in this example)
 

--- a/README.rst
+++ b/README.rst
@@ -171,3 +171,15 @@ To install your package with pip::
 
  $ pip install -i http://my.pypiserver.com/simple/ <PACKAGE>
 
+If you want to fall back to PyPi or another repository in the event the
+package is not on your new server, or if you are installing a number
+of packages, some on your private server and some on another, you can use::
+
+ $ pip install -i http://localhost:8000/simple/ \
+   --extra-index-url=http://pypi.python.org/simple/
+
+(substitute your djangopypi server URL for the ``localhost`` one in this example)
+
+The downside is that each install of a package hosted on the repository in
+``--extra-index-url`` will start with a call to the first repository which
+will fail before pip falls back to the alternative.


### PR DESCRIPTION
This replaces PR #51 https://github.com/benliles/djangopypi/pull/51 which was from the wrong branch in this fork. This also adds additional notes regarding enabling proxying to upstream indexes.

The original comment for PR 51:

In installing djangopypi for the first time I found that the README was not sufficiently complete for new users. Whilst I could see what was required get get package upload and download working, it could slow down others or cause them to give up.

I have therefore added to the README file in a way that I think helps.
